### PR TITLE
[WIP] Make Rialto Views open

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ formatting throughout your app by using annotations in your string resources.
 * [Cascading Registry](#cascading-registry)
 * [Format Strings](#format-strings)
 * [Downloadable Fonts](#downloadable-fonts)
+* [View Subclasses](#view-subclasses)
 * [Java Interoperability](#java-interoperability)
 * [Internals](#internals)
 
@@ -384,6 +385,14 @@ The attribute names match those of the second argument to the registerFonts() me
 It is worth noting that since V1.2.0 Rialto is case insensitive, so using a font name of “Pacifico” is identical to using “pacifico”.
 
 There’s really nothing more to this – registering your preloaded_fonts array using FontRegistrar does all that you need, and you just need to use the appropriate annotations within your string resources to make use of them.
+
+#### View Subclasses
+
+Using Rialto with View (EditText, TextInputEditText or TextView) subclasses is simple, but requires one additional simple step:
+
+Extend your subclass from the according `Rialto*` View instead of the support/material/appcompat class, e.g. use `RialtoTextView` as your `MyTextView` superclass instead of `TextView`.
+
+This will enable all Rialto features in your subclass as well.
 
 #### Java Interoperability
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,7 +3,7 @@ ext {
     androidTargetSdkVersion = 28
     androidCompileSdkVersion = 28
 
-    androidBuildToolsVersion = '3.4.0-alpha08'
+    androidBuildToolsVersion = '3.4.0'
 
     supportLibraryVersion = '28.0.0'
     androidXLibraryVersion = '1.0.2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Nov 17 12:18:00 GMT 2018
+#Sat Apr 27 11:02:07 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/library/src/commonx/java/com/stylingandroid/rialto/androidx/widget/RialtoEditText.kt
+++ b/library/src/commonx/java/com/stylingandroid/rialto/androidx/widget/RialtoEditText.kt
@@ -8,7 +8,7 @@ import androidx.appcompat.widget.AppCompatEditText
 import com.stylingandroid.rialto.RialtoTextDelegate
 import com.stylingandroid.rialto.TextViewDelegate
 
-class RialtoEditText @JvmOverloads constructor(
+open class RialtoEditText @JvmOverloads constructor(
     context: Context,
     private val attrs: AttributeSet? = null,
     defaultStyle: Int = R.attr.editTextStyle

--- a/library/src/commonx/java/com/stylingandroid/rialto/androidx/widget/RialtoTextView.kt
+++ b/library/src/commonx/java/com/stylingandroid/rialto/androidx/widget/RialtoTextView.kt
@@ -6,7 +6,7 @@ import android.widget.TextView
 import androidx.appcompat.widget.AppCompatTextView
 import com.stylingandroid.rialto.TextViewDelegate
 
-class RialtoTextView @JvmOverloads constructor(
+open class RialtoTextView @JvmOverloads constructor(
     context: Context,
     private val attrs: AttributeSet? = null,
     defaultStyle: Int = 0

--- a/library/src/material/java/com/stylingandroid/rialto/material/widget/RialtoTextInputEditText.kt
+++ b/library/src/material/java/com/stylingandroid/rialto/material/widget/RialtoTextInputEditText.kt
@@ -8,7 +8,7 @@ import com.stylingandroid.rialto.RialtoTextDelegate
 import com.stylingandroid.rialto.TextViewDelegate
 import kotlinx.coroutines.CoroutineScope
 
-class RialtoTextInputEditText @JvmOverloads constructor(
+open class RialtoTextInputEditText @JvmOverloads constructor(
         context: Context,
         private val attrs: AttributeSet? = null,
         defaultStyle: Int = 0

--- a/library/src/support/java/com/stylingandroid/rialto/support/widget/RialtoEditText.kt
+++ b/library/src/support/java/com/stylingandroid/rialto/support/widget/RialtoEditText.kt
@@ -7,7 +7,7 @@ import android.util.AttributeSet
 import android.widget.TextView
 import com.stylingandroid.rialto.TextViewDelegate
 
-class RialtoEditText @JvmOverloads constructor(
+open class RialtoEditText @JvmOverloads constructor(
     context: Context,
     private val attrs: AttributeSet? = null,
     defaultStyle: Int = R.attr.editTextStyle

--- a/library/src/support/java/com/stylingandroid/rialto/support/widget/RialtoTextView.kt
+++ b/library/src/support/java/com/stylingandroid/rialto/support/widget/RialtoTextView.kt
@@ -6,7 +6,7 @@ import android.util.AttributeSet
 import android.widget.TextView
 import com.stylingandroid.rialto.TextViewDelegate
 
-class RialtoTextView @JvmOverloads constructor(
+open class RialtoTextView @JvmOverloads constructor(
     context: Context,
     private val attrs: AttributeSet? = null,
     defaultStyle: Int = 0


### PR DESCRIPTION
This makes all Rialto Views in all flavors open to enable Rialto features in View subclasses as well.

Consider this PR a fallback solution if we don't find another more generic solution for #5, I'd like to keep it open until we've come to a conclusion there.

If we decide to go with this PR's solution we might also want to make the delegates non-internal in case people don't want to/cannot subclass Rialto views.

PS.: I've also sneaked in version bumps for AGP and Gradle to make the project compatible with AS 3.4 stable.